### PR TITLE
Use correct renovate datasource for updating openjdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update -y && \
 
 # Install OpenJDK
 
-# renovate: datasource=adoptium depName=java-jdk versioning=loose
+# renovate: datasource=adoptium-java depName=java-jdk versioning=loose
 ENV OPENJDK_VERSION=17.0.4.0.0+8
 
 RUN apt-get update -y && \


### PR DESCRIPTION
Correct openjdk datasource for renovate to official identifier according to https://docs.renovatebot.com/modules/datasource/#adoptium-java-datasource

Fixes #11