### PR TITLE
Rename repository for JDK 17

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,12 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>swissgrc/renovate-presets:docker"
+  ],
+  "packageRules": [
+    {
+      "matchDepNames": [ "java-jdk" ],
+      "description": "No JDK Major Updates",      
+      "extends": [ ":disableMajorUpdates" ]
+    }
   ]
 }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,9 @@ jobs:
     uses: swissgrc/.github/.github/workflows/publish-image.yml@main
     with:
       image-name: swissgrc/azure-pipelines-openjdk
+      default-latest-tag: true
+      additional-latest-tag-name: 17
+      unstable-tag-name: 17-unstable
     secrets:
       gh-token: ${{ secrets.GITHUB_TOKEN }}
       docker-username: ${{ secrets.DOCKER_USERNAME }}

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Docker image for running Java applications in an Azure Pipelines container job
 
 <!-- markdownlint-disable MD013 -->
-[![License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/swissgrc/docker-azure-pipelines-openjdk/blob/main/LICENSE) [![Build](https://img.shields.io/github/actions/workflow/status/swissgrc/docker-azure-pipelines-openjdk/publish.yml?branch=develop&style=flat-square)](https://github.com/swissgrc/docker-azure-pipelines-openjdk/actions/workflows/publish.yml) [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=swissgrc_docker-azure-pipelines-openjdk&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=swissgrc_docker-azure-pipelines-openjdk) [![Pulls](https://img.shields.io/docker/pulls/swissgrc/azure-pipelines-openjdk.svg?style=flat-square)](https://hub.docker.com/r/swissgrc/azure-pipelines-openjdk) [![Stars](https://img.shields.io/docker/stars/swissgrc/azure-pipelines-openjdk.svg?style=flat-square)](https://hub.docker.com/r/swissgrc/azure-pipelines-openjdk)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/swissgrc/docker-azure-pipelines-openjdk-17/blob/main/LICENSE) [![Build](https://img.shields.io/github/actions/workflow/status/swissgrc/docker-azure-pipelines-openjdk-17/publish.yml?branch=develop&style=flat-square)](https://github.com/swissgrc/docker-azure-pipelines-openjdk-17/actions/workflows/publish.yml) [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=swissgrc_docker-azure-pipelines-openjdk-17&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=swissgrc_docker-azure-pipelines-openjdk-17) [![Pulls](https://img.shields.io/docker/pulls/swissgrc/azure-pipelines-openjdk.svg?style=flat-square)](https://hub.docker.com/r/swissgrc/azure-pipelines-openjdk) [![Stars](https://img.shields.io/docker/stars/swissgrc/azure-pipelines-openjdk.svg?style=flat-square)](https://hub.docker.com/r/swissgrc/azure-pipelines-openjdk)
 <!-- markdownlint-restore -->
 
-Docker image which provides [Eclipse Temurin OpenJDK] in an [Azure Pipelines container jobs].
+Docker image which provides [Eclipse Temurin OpenJDK] 17 in an [Azure Pipelines container jobs].
 The image contains also Docker CLI to access Docker engine on the agent.
 
 ## Usage

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,8 +1,8 @@
-sonar.projectKey=swissgrc_docker-azure-pipelines-openjdk
+sonar.projectKey=swissgrc_docker-azure-pipelines-openjdk-17
 sonar.organization=swissgrc-opensource
 
 # This is the name and version displayed in the SonarCloud UI.
-sonar.projectName=docker-azure-pipelines-openjdk
+sonar.projectName=docker-azure-pipelines-openjdk-17
 #sonar.projectVersion=1.0
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.


### PR DESCRIPTION
Adds JDK version number to repository name, since next JDK LTS release will be provided from a separate repository.