### PR TITLE
No longer build latest and unstable tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,9 +14,9 @@ jobs:
     uses: swissgrc/.github/.github/workflows/publish-image.yml@main
     with:
       image-name: swissgrc/azure-pipelines-openjdk
-      default-latest-tag: true
+      default-latest-tag: false
       additional-latest-tag-name: 17
-      default-unstable-tag: true
+      default-unstable-tag: false
       additional-unstable-tag-name: 17-unstable
     secrets:
       gh-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The following example shows the container used for a deployment step which shows
   - stage: deploy
     jobs:
       - deployment: runJava
-        container: swissgrc/azure-pipelines-openjdk:latest
+        container: swissgrc/azure-pipelines-openjdk:17
         environment: smarthotel-dev
         strategy:
           runOnce:
@@ -35,9 +35,8 @@ The following example shows the container used for a deployment step which shows
 
 | Tag         | Description                                                                                   | Base Image                       | OpenJDK   | Size                                                                                                                                |
 |-------------|-----------------------------------------------------------------------------------------------|----------------------------------|-----------|-------------------------------------------------------------------------------------------------------------------------------------|
-| latest      | Latest stable release (from `main` branch)                                                    | azure-pipelines-dockercli:24.0.7 | 17.0.9.0  | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-openjdk/latest?style=flat-square)      |
-| unstable    | Latest unstable release (from `develop` branch)                                               | azure-pipelines-dockercli:25.0.3 | 17.0.10.0 | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-openjdk/unstable?style=flat-square)    |
-| 17-unstable | Identical to `unstable` tag                                                                   |                                  |           | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-openjdk/17-unstable?style=flat-square) |
+| 17          | Latest stable release (from `main` branch)                                                    | azure-pipelines-dockercli:24.0.7 | 17.0.9.0  | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-openjdk/17?style=flat-square)          |
+| 17-unstable | Latest unstable release (from `develop` branch)                                               | azure-pipelines-dockercli:25.0.3 | 17.0.10.0 | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-openjdk/17-unstable?style=flat-square) |
 | 17.0.4.0    | [OpenJDK 17.0.4](https://foojay.io/java-17/?tab=component&version=17.0.4&quarter=072022)      | debian:11.3-slim                 | 17.0.4.0  | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-openjdk/17.0.4.0?style=flat-square)    |
 | 17.0.4.1    | [OpenJDK 17.0.4](https://foojay.io/java-17/?tab=component&version=17.0.4&quarter=072022)      | debian:11.5-slim                 | 17.0.4.1  | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-openjdk/17.0.4.1?style=flat-square)    |
 | 17.0.5.0    | [OpenJDK 17.0.5](https://foojay.io/java-17/?tab=component&version=17.0.5&quarter=102022)      | debian:11.6-slim                 | 17.0.5.0  | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-openjdk/17.0.5.0?style=flat-square)    |


### PR DESCRIPTION
No longer build latest and unstable tag from this repository, since OpenJDK 21 is now the latest version